### PR TITLE
reference was named with an s I removed to be good

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 <ul>
   <li><a href="/american/burger">Greasy Hamburger</a></li>
   <li><a href="/american/pizza">Fly Pizza</a></li>
-  <li><a href="/american/hotdogs">Traditional Ballpark Hotdog</a></li>
+  <li><a href="/american/hotdog">Traditional Ballpark Hotdog</a></li>
 </ul>
 
 <h2>🏯 Japanese</h2>


### PR DESCRIPTION
the folder did not have an s in the name so the link was pointing to the wrong folder. 